### PR TITLE
Integra consult  postgres 5.7.1 extra fixes

### DIFF
--- a/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclNativeHelper.php
+++ b/src/Kunstmaan/AdminBundle/Helper/Security/Acl/AclNativeHelper.php
@@ -51,42 +51,23 @@ class AclNativeHelper
     }
 
     /**
-     * Apply the ACL constraints to the specified query builder, using the permission definition, for all database platforms
-     *
-     * @param QueryBuilder         $queryBuilder  The query builder
-     * @param PermissionDefinition $permissionDef The permission definition
+     * Apply the ACL constraints to the specified query builder, using the permission definition, for all database platforms.
      *
      * @return QueryBuilder
      */
     public function apply(QueryBuilder $queryBuilder, PermissionDefinition $permissionDef)
     {
-        if ($this->em->getConnection()->getDatabasePlatform()->getName() == 'postgresql') {
-            return $this->applyPlatformPostgres($queryBuilder, $permissionDef);
-        }
-
-        return $this->applyPlatformOther($queryBuilder, $permissionDef);
-    }
-
-    /**
-     * Apply the ACL constraints to the specified query builder, using the permission definition for all postgres platform
-     *
-     * @return QueryBuilder
-     */
-    private function applyPlatformPostgres(QueryBuilder $queryBuilder, PermissionDefinition $permissionDef)
-    {
         if (!$this->permissionsEnabled) {
             return $queryBuilder;
         }
 
-        $aclConnection = $this->em->getConnection();
-        $stringQuoteChar = $aclConnection->getDatabasePlatform()->getStringLiteralQuoteCharacter();
-
+        $databasePlatform = $this->em->getConnection()->getDatabasePlatform();
         $rootEntity = $permissionDef->getEntity();
         $linkAlias = $permissionDef->getAlias();
         // Only tables with a single ID PK are currently supported
         $linkField = $this->em->getClassMetadata($rootEntity)->getSingleIdentifierColumnName();
 
-        $rootEntity = $stringQuoteChar . $rootEntity . $stringQuoteChar;
+        $rootEntity = $databasePlatform->quoteStringLiteral($rootEntity);
         $query = $queryBuilder;
 
         $builder = new MaskBuilder();
@@ -111,18 +92,18 @@ class AclNativeHelper
         }
 
         // Security context does not provide anonymous role automatically.
-        $uR = [$stringQuoteChar . 'IS_AUTHENTICATED_ANONYMOUSLY' . $stringQuoteChar];
+        $uR = [$databasePlatform->quoteStringLiteral('IS_AUTHENTICATED_ANONYMOUSLY')];
 
         foreach ($userRoles as $role) {
             // The reason we ignore this is because by default FOSUserBundle adds ROLE_USER for every user
             if (is_string($role)) {
                 if ($role !== 'ROLE_USER') {
-                    $uR[] = $stringQuoteChar . $role . $stringQuoteChar;
+                    $uR[] = $databasePlatform->quoteStringLiteral($role);
                 }
             } else {
                 // Symfony 3.4 compatibility
                 if ($role->getRole() !== 'ROLE_USER') {
-                    $uR[] = $stringQuoteChar . $role->getRole() . $stringQuoteChar;
+                    $uR[] = $databasePlatform->quoteStringLiteral($role->getRole());
                 }
             }
         }
@@ -130,12 +111,12 @@ class AclNativeHelper
         $inString = implode(' OR s.identifier = ', $uR);
 
         if (\is_object($user)) {
-            $inString .= ' OR s.identifier = ' . $stringQuoteChar . \get_class($user) . '-' . $user->getUserName() . $stringQuoteChar;
+            $inString .= ' OR s.identifier = '.$databasePlatform->quoteStringLiteral(\get_class($user) . '-' . $user->getUserName());
         }
 
         $objectIdentifierColumn = 'o.object_identifier';
-        if ($aclConnection->getDatabasePlatform()->getName() === 'postgresql') {
-            $objectIdentifierColumn = 'o.object_identifier::BIGINT';
+        if ($databasePlatform->getName() === 'postgresql') {
+            $objectIdentifierColumn .= '::BIGINT';
         }
 
         $joinTableQuery = <<<SELECTQUERY
@@ -143,98 +124,9 @@ SELECT DISTINCT {$objectIdentifierColumn} as id FROM acl_object_identities as o
 INNER JOIN acl_classes c ON c.id = o.class_id
 LEFT JOIN acl_entries e ON (
     e.class_id = o.class_id AND (e.object_identity_id = o.id
-    OR {$aclConnection->getDatabasePlatform()->getIsNullExpression('e.object_identity_id')})
+    OR {$databasePlatform->getIsNullExpression('e.object_identity_id')})
 )
 LEFT JOIN acl_security_identities s ON (
-s.id = e.security_identity_id
-)
-WHERE c.class_type = {$rootEntity}
-AND (s.identifier = {$inString})
-AND e.mask & {$mask} > 0
-SELECTQUERY;
-        $query->join($linkAlias, '(' . $joinTableQuery . ')', 'perms_', 'perms_.id = ' . $linkAlias . '.' . $linkField);
-
-        return $query;
-    }
-
-    /**
-     * Apply the ACL constraints to the specified query builder, using the permission definition for all platforms other than postgres
-     *
-     * @return QueryBuilder
-     */
-    private function applyPlatformOther(QueryBuilder $queryBuilder, PermissionDefinition $permissionDef)
-    {
-        if (!$this->permissionsEnabled) {
-            return $queryBuilder;
-        }
-
-        $aclConnection = $this->em->getConnection();
-
-        $databasePrefix = is_file($aclConnection->getDatabase()) ? '' : $aclConnection->getDatabase() . '.';
-        $rootEntity = $permissionDef->getEntity();
-        $linkAlias = $permissionDef->getAlias();
-        // Only tables with a single ID PK are currently supported
-        $linkField = $this->em->getClassMetadata($rootEntity)->getSingleIdentifierColumnName();
-
-        $rootEntity = '"' . str_replace('\\', '\\\\', $rootEntity) . '"';
-        $query = $queryBuilder;
-
-        $builder = new MaskBuilder();
-        foreach ($permissionDef->getPermissions() as $permission) {
-            $mask = \constant(\get_class($builder) . '::MASK_' . strtoupper($permission));
-            $builder->add($mask);
-        }
-        $mask = $builder->get();
-
-        /* @var $token TokenInterface */
-        $token = $this->tokenStorage->getToken();
-        $userRoles = [];
-        $user = null;
-        if (!\is_null($token)) {
-            $user = $token->getUser();
-            if (method_exists($this->roleHierarchy, 'getReachableRoleNames')) {
-                $userRoles = $this->roleHierarchy->getReachableRoleNames($token->getRoleNames());
-            } else {
-                // Symfony 3.4 compatibility
-                $userRoles = $this->roleHierarchy->getReachableRoles($token->getRoles());
-            }
-        }
-
-        // Security context does not provide anonymous role automatically.
-        $uR = ['"IS_AUTHENTICATED_ANONYMOUSLY"'];
-
-        foreach ($userRoles as $role) {
-            // The reason we ignore this is because by default FOSUserBundle adds ROLE_USER for every user
-            if (is_string($role)) {
-                if ($role !== 'ROLE_USER') {
-                    $uR[] = '"' . $role . '"';
-                }
-            } else {
-                // Symfony 3.4 compatibility
-                if ($role->getRole() !== 'ROLE_USER') {
-                    $uR[] = '"' . $role->getRole() . '"';
-                }
-            }
-        }
-        $uR = array_unique($uR);
-        $inString = implode(' OR s.identifier = ', $uR);
-
-        if (\is_object($user)) {
-            $inString .= ' OR s.identifier = "' . str_replace(
-                '\\',
-                '\\\\',
-                \get_class($user)
-            ) . '-' . $user->getUserName() . '"';
-        }
-
-        $joinTableQuery = <<<SELECTQUERY
-SELECT DISTINCT o.object_identifier as id FROM {$databasePrefix}acl_object_identities as o
-INNER JOIN {$databasePrefix}acl_classes c ON c.id = o.class_id
-LEFT JOIN {$databasePrefix}acl_entries e ON (
-    e.class_id = o.class_id AND (e.object_identity_id = o.id
-    OR {$aclConnection->getDatabasePlatform()->getIsNullExpression('e.object_identity_id')})
-)
-LEFT JOIN {$databasePrefix}acl_security_identities s ON (
 s.id = e.security_identity_id
 )
 WHERE c.class_type = {$rootEntity}

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/AclHelperTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/AclHelperTest.php
@@ -5,6 +5,7 @@ namespace Kunstmaan\AdminBundle\Tests\Helper\Security\Acl;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -71,15 +72,9 @@ class AclHelperTest extends TestCase
             ->method('getDatabase')
             ->will($this->returnValue('myDatabase'));
 
-        /* @var $platform AbstractPlatform */
-        $platform = $this->createMock(AbstractPlatform::class);
-        $platform->expects($this->any())
-            ->method('getStringLiteralQuoteCharacter')
-            ->willReturn($this->returnValue('#'));
-
         $conn->expects($this->any())
             ->method('getDatabasePlatform')
-            ->will($this->returnValue($platform));
+            ->willReturn(new MySqlPlatform());
 
         /* @var $stmt Statement */
         $stmt = $this->createMock(Statement::class);

--- a/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/AclNativeHelperTest.php
+++ b/src/Kunstmaan/AdminBundle/Tests/Helper/Security/Acl/AclNativeHelperTest.php
@@ -4,6 +4,7 @@ namespace Kunstmaan\AdminBundle\Tests\Helper\Security\Acl;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -69,15 +70,9 @@ class AclNativeHelperTest extends TestCase
             ->method('getDatabase')
             ->will($this->returnValue('myDatabase'));
 
-        /* @var $platform AbstractPlatform */
-        $platform = $this->createMock(AbstractPlatform::class);
-        $platform->expects($this->any())
-            ->method('getStringLiteralQuoteCharacter')
-            ->willReturn($this->returnValue('#'));
-
         $this->conn->expects($this->any())
             ->method('getDatabasePlatform')
-            ->will($this->returnValue($platform));
+            ->willReturn(new MySqlPlatform());
 
         $this->em->expects($this->any())
             ->method('getConnection')

--- a/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineDBALAdminListConfigurator.php
+++ b/src/Kunstmaan/AdminListBundle/AdminList/Configurator/AbstractDoctrineDBALAdminListConfigurator.php
@@ -38,13 +38,9 @@ abstract class AbstractDoctrineDBALAdminListConfigurator extends AbstractAdminLi
      */
     private $useDistinctCount = true;
 
-    private $databasePlatform;
-
     public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $platform = $connection->getDatabasePlatform();
-        $this->databasePlatform = ($platform) ? $platform->getName() : 'mysql';
     }
 
     /**
@@ -92,8 +88,7 @@ abstract class AbstractDoctrineDBALAdminListConfigurator extends AbstractAdminLi
             $adapter = new DoctrineDBALAdapter(
                 $this->getQueryBuilder(),
                 $this->getCountField(),
-                $this->getUseDistinctCount(),
-                $this->databasePlatform
+                $this->getUseDistinctCount()
             );
             $this->pagerfanta = new Pagerfanta($adapter);
             $this->pagerfanta->setMaxPerPage($this->getLimit());

--- a/src/Kunstmaan/AdminListBundle/Helper/DoctrineDBALAdapter.php
+++ b/src/Kunstmaan/AdminListBundle/Helper/DoctrineDBALAdapter.php
@@ -22,18 +22,13 @@ class DoctrineDBALAdapter implements AdapterInterface
     private $useDistinct;
 
     /**
-     * @var mixed|string
-     */
-    private $databasePlatform;
-
-    /**
      * @param QueryBuilder $queryBuilder a DBAL query builder
      * @param string       $countField   Primary key for the table in query. Used in count expression. Must include table alias
      * @param bool         $useDistinct  when set to true it'll count the countfield with a distinct in front of it
      *
      * @api
      */
-    public function __construct(QueryBuilder $queryBuilder, $countField, $useDistinct = true, $databasePlatform = 'mysql')
+    public function __construct(QueryBuilder $queryBuilder, $countField, $useDistinct = true)
     {
         if (strpos($countField, '.') === false) {
             throw new LogicException('The $countField must contain a table alias in the string.');
@@ -46,7 +41,6 @@ class DoctrineDBALAdapter implements AdapterInterface
         $this->queryBuilder = $queryBuilder;
         $this->countField = $countField;
         $this->useDistinct = $useDistinct;
-        $this->databasePlatform = $databasePlatform;
     }
 
     /**

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/Configurator/AbstractDoctrineDBALAdminListConfiguratorTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/Configurator/AbstractDoctrineDBALAdminListConfiguratorTest.php
@@ -56,9 +56,7 @@ class AbstractDoctrineDBALAdminListConfiguratorTest extends TestCase
     public function testGetPagerFanta()
     {
         $abstractMock = $this->setUpAbstractMock();
-        if ($abstractMock) {
-            $this->assertInstanceOf(Pagerfanta::class, $abstractMock->getPagerfanta());
-        }
+        $this->assertInstanceOf(Pagerfanta::class, $abstractMock->getPagerfanta());
     }
 
     public function testGetQueryBuilderAndIterator()

--- a/src/Kunstmaan/AdminListBundle/Tests/AdminList/Helper/DoctrineDBALAdapterTest.php
+++ b/src/Kunstmaan/AdminListBundle/Tests/AdminList/Helper/DoctrineDBALAdapterTest.php
@@ -59,15 +59,11 @@ class DoctrineDBALAdapterTest extends TestCase
         $statement->expects($this->once())->method('fetchColumn')->with(0)->willReturn([1, 2, 3]);
 
         $qb = $this->createMock(QueryBuilder::class);
-
         $qb->expects($this->once())->method('getType')->willReturn(QueryBuilder::SELECT);
         $qb->expects($this->once())->method('select')->willReturn($qb);
-        // these 2 statments are valid for mysql only, not postgres
-        //$qb->expects($this->once())->method('orderBy')->willReturn($qb);
-        //$qb->expects($this->once())->method('setMaxResults')->with(1)->willReturn($qb);
         $qb->expects($this->once())->method('execute')->willReturn($statement);
 
-        $adapter = new DoctrineDBALAdapter($qb, 'table.somefield', true, 'postgresql');
+        $adapter = new DoctrineDBALAdapter($qb, 'table.somefield');
         $result = $adapter->getNbResults();
         $this->assertCount(3, $result);
     }
@@ -79,12 +75,9 @@ class DoctrineDBALAdapterTest extends TestCase
         $qb = $this->createMock(QueryBuilder::class);
         $qb->expects($this->once())->method('getType')->willReturn(QueryBuilder::SELECT);
         $qb->expects($this->once())->method('select')->willReturn($qb);
-        // these two tests are  only valid for mysql , not for postgresql
-        //$qb->expects($this->once())->method('orderBy')->willReturn($qb);
-        //$qb->expects($this->once())->method('setMaxResults')->with(1)->willReturn($qb);
         $qb->expects($this->once())->method('execute')->willReturn($statement);
 
-        $adapter = new DoctrineDBALAdapter($qb, 'table.somefield', true, 'postgresql');
+        $adapter = new DoctrineDBALAdapter($qb, 'table.somefield');
         $result = $adapter->getNbResults();
         $this->assertSame(0, $result);
     }

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Category.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Category.php
@@ -9,7 +9,6 @@ use {{ namespace }}\Form\{{ entity_class }}CategoryAdminType;
 
 /**
  * @ORM\Entity()
- * For postgresql compatibility UniqueConstraint names need to be unique
  * @ORM\Table(name="{{ prefix }}{{ entity_class|lower }}_categories", uniqueConstraints={@ORM\UniqueConstraint(name="{{ entity_class|lower }}_category_name_idx", columns={"name"})})
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */

--- a/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Tag.php
+++ b/src/Kunstmaan/GeneratorBundle/Resources/SensioGeneratorBundle/skeleton/article/Entity/Tag.php
@@ -9,7 +9,6 @@ use {{ namespace }}\Form\{{ entity_class }}TagAdminType;
 
 /**
  * @ORM\Entity()
- * For postgresql compatibility UniqueConstraint names need to be unique
  * @ORM\Table(name="{{ prefix }}{{ entity_class|lower }}_tags", uniqueConstraints={@ORM\UniqueConstraint(name="{{ entity_class|lower }}_tag_name_idx", columns={"name"})})
  * @Gedmo\SoftDeleteable(fieldName="deletedAt")
  */

--- a/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
@@ -513,15 +513,15 @@ class NodeTranslationRepository extends EntityRepository
             'nt'
         );
 
-        $query = $em
-            ->createNativeQuery(
-                'select nt.*
-                         from kuma_node_translations nt
-                        join kuma_nodes n on n.id = nt.node_id
-                        where n.deleted = :deleted and nt.lang = :lang and locate(nt.url, :url) = 1
-                        order by length(nt.url) desc limit 1',
-                $rsm
-            );
+        $query = $em->createNativeQuery('
+            select nt.*
+            from kuma_node_translations nt
+            join kuma_nodes n on n.id = nt.node_id
+            where n.deleted = :deleted and nt.lang = :lang and locate(nt.url, :url) = 1
+            order by length(nt.url) desc limit 1
+            ',
+            $rsm
+        );
 
         $query->setParameter('lang', $locale);
         $query->setParameter('url', $urlSlug);

--- a/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
+++ b/src/Kunstmaan/NodeBundle/Repository/NodeTranslationRepository.php
@@ -75,29 +75,13 @@ class NodeTranslationRepository extends EntityRepository
      */
     public function getMaxChildrenWeight(Node $parentNode = null, $lang = null)
     {
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() == 'postgresql') {
-            $maxWeights = $this->getNodeTranslationsQueryBuilder($lang)
-                ->select('max(nt.weight)')
-                ->andWhere('n.parent = :parentNode')
-                ->setParameter('parentNode', $parentNode)
-                ->groupBy('nt.weight') /// thjis one
-                ->getQuery()
-                ->getScalarResult();
-            $maxWeight = -1000;
-            foreach ($maxWeights as $entry) {
-                $weight = array_values($entry)[0];
-                if ($weight > $maxWeight) {
-                    $maxWeight = $weight;
-                }
-            }
-        } else {
-            $maxWeight = $this->getNodeTranslationsQueryBuilder($lang)
-                ->select('max(nt.weight)')
-                ->andWhere('n.parent = :parentNode')
-                ->setParameter('parentNode', $parentNode)
-                ->getQuery()
-                ->getSingleScalarResult();
-        }
+        $maxWeight = $this->getNodeTranslationsQueryBuilder($lang)
+            ->select('max(nt.weight)')
+            ->andWhere('n.parent = :parentNode')
+            ->setParameter('parentNode', $parentNode)
+            ->resetDQLPart('orderBy')
+            ->getQuery()
+            ->getSingleScalarResult();
 
         return (int) $maxWeight;
     }


### PR DESCRIPTION
Key changes:

- Don't duplicate the queries and only apply specific changes between mysql/postgres
- Use the doctrine built-in function`quoteStringLiteral` to use the correct quote character and let doctrine decided if `\` should be escaped (based on the platform)
- Removed unused properties of previous changes
- Removed some "useless" comments (the git commit message will provide enough info about the change)
- Simplified the max `getMaxChildrenWeight` query as the real issue was the order by clause and this doesn't make sense in combination with a max function